### PR TITLE
Fix metadata in JOSS paper source

### DIFF
--- a/JOSS/paper.md
+++ b/JOSS/paper.md
@@ -36,8 +36,8 @@ authors:
     orcid: 
     affiliation: 1
   - name: Xieyuan Dong
-   orcid: 
-   affiliation: 6
+    orcid: 
+    affiliation: 6
   - name: Zhiheng Wang
     orcid: 0009-0000-5088-6207
     affiliation: 1


### PR DESCRIPTION
A small change that fixes the indentation of the YAML metadata in the [recently submitted](https://github.com/openjournals/joss-reviews/issues/7487) JOSS paper. The paper builds locally with this change, so once merged you can try `@editorialbot generate pdf` again.