### PR TITLE
Fix α-fixed pressure in NL RMF generators (ω⁴ and ω-ρ cross-coupling)

### DIFF
--- a/EOSgenerators/RMF_EOS.py
+++ b/EOSgenerators/RMF_EOS.py
@@ -549,13 +549,20 @@ def get_energy_pressure_alpha(x, rho, theta):
 
     sigma_terms =  0.5*((sigma*m_sig)**2) + (kappa*((g_sigma*sigma)**3))/6.\
                     + (lambda_0*((g_sigma*sigma)**4))/24.
-        
-    omega_terms = 0.5*((omega*m_w)**2) +(zeta*((g_omega*omega)**4))/8.
-        
-    rho_terms = 0.5*((rho_03*m_rho)**2)+ 3.*Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
-    
-    energy_density = energy_b   + sigma_terms + omega_terms + rho_terms
-    Pressure       = Pressure_p + Pressure_n  - sigma_terms + omega_terms + rho_terms
+
+    # ε uses post-MF-substitution coefficients (ζ/8, 3·Λ_w); they absorb the matter-
+    # meson coupling g_ω·ω·ρ_B via the ω-field equation of motion.
+    omega_eps_terms = 0.5*((omega*m_w)**2) + (zeta*((g_omega*omega)**4))/8.
+    rho_eps_terms   = 0.5*((rho_03*m_rho)**2) + 3.*Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
+
+    # P uses the raw Lagrangian coefficients (ζ/24, 1·Λ_w); P = T^{ii} carries no
+    # matter-meson coupling to substitute.  The old code reused the ε coefficients,
+    # which overstated P by (ζ/12)(g_ω ω)⁴ + 2·Λ_w (g_ρ ρ_03 g_ω ω)².
+    omega_P_terms   = 0.5*((omega*m_w)**2) + (zeta*((g_omega*omega)**4))/24.
+    rho_P_terms     = 0.5*((rho_03*m_rho)**2) + Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
+
+    energy_density = energy_b   + sigma_terms + omega_eps_terms + rho_eps_terms
+    Pressure       = Pressure_p + Pressure_n  - sigma_terms + omega_P_terms   + rho_P_terms
 
     return energy_density, Pressure
 

--- a/EOSgenerators/fastRMF_EoS.py
+++ b/EOSgenerators/fastRMF_EoS.py
@@ -572,13 +572,20 @@ def get_energy_pressure_alpha(x, rho, theta):
 
     sigma_terms =  0.5*((sigma*m_sig)**2) + (kappa*((g_sigma*sigma)**3))/6.\
                     + (lambda_0*((g_sigma*sigma)**4))/24.
-        
-    omega_terms = 0.5*((omega*m_w)**2) +(zeta*((g_omega*omega)**4))/8.
-        
-    rho_terms = 0.5*((rho_03*m_rho)**2)+ 3.*Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
-    
-    energy_density = energy_b   + sigma_terms + omega_terms + rho_terms
-    Pressure       = Pressure_p + Pressure_n  - sigma_terms + omega_terms + rho_terms
+
+    # ε uses post-MF-substitution coefficients (ζ/8, 3·Λ_w); they absorb the matter-
+    # meson coupling g_ω·ω·ρ_B via the ω-field equation of motion.
+    omega_eps_terms = 0.5*((omega*m_w)**2) + (zeta*((g_omega*omega)**4))/8.
+    rho_eps_terms   = 0.5*((rho_03*m_rho)**2) + 3.*Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
+
+    # P uses the raw Lagrangian coefficients (ζ/24, 1·Λ_w); P = T^{ii} carries no
+    # matter-meson coupling to substitute.  The old code reused the ε coefficients,
+    # which overstated P by (ζ/12)(g_ω ω)⁴ + 2·Λ_w (g_ρ ρ_03 g_ω ω)².
+    omega_P_terms   = 0.5*((omega*m_w)**2) + (zeta*((g_omega*omega)**4))/24.
+    rho_P_terms     = 0.5*((rho_03*m_rho)**2) + Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
+
+    energy_density = energy_b   + sigma_terms + omega_eps_terms + rho_eps_terms
+    Pressure       = Pressure_p + Pressure_n  - sigma_terms + omega_P_terms   + rho_P_terms
 
     return energy_density, Pressure
 

--- a/docs/source/fastRMF_EoS.py
+++ b/docs/source/fastRMF_EoS.py
@@ -570,13 +570,20 @@ def get_energy_pressure_alpha(x, rho, theta):
 
     sigma_terms =  0.5*((sigma*m_sig)**2) + (kappa*((g_sigma*sigma)**3))/6.\
                     + (lambda_0*((g_sigma*sigma)**4))/24.
-        
-    omega_terms = 0.5*((omega*m_w)**2) +(zeta*((g_omega*omega)**4))/8.
-        
-    rho_terms = 0.5*((rho_03*m_rho)**2)+ 3.*Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
-    
-    energy_density = energy_b   + sigma_terms + omega_terms + rho_terms
-    Pressure       = Pressure_p + Pressure_n  - sigma_terms + omega_terms + rho_terms
+
+    # ε uses post-MF-substitution coefficients (ζ/8, 3·Λ_w); they absorb the matter-
+    # meson coupling g_ω·ω·ρ_B via the ω-field equation of motion.
+    omega_eps_terms = 0.5*((omega*m_w)**2) + (zeta*((g_omega*omega)**4))/8.
+    rho_eps_terms   = 0.5*((rho_03*m_rho)**2) + 3.*Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
+
+    # P uses the raw Lagrangian coefficients (ζ/24, 1·Λ_w); P = T^{ii} carries no
+    # matter-meson coupling to substitute.  The old code reused the ε coefficients,
+    # which overstated P by (ζ/12)(g_ω ω)⁴ + 2·Λ_w (g_ρ ρ_03 g_ω ω)².
+    omega_P_terms   = 0.5*((omega*m_w)**2) + (zeta*((g_omega*omega)**4))/24.
+    rho_P_terms     = 0.5*((rho_03*m_rho)**2) + Lambda_w*((g_rho*rho_03*g_omega*omega)**2)
+
+    energy_density = energy_b   + sigma_terms + omega_eps_terms + rho_eps_terms
+    Pressure       = Pressure_p + Pressure_n  - sigma_terms + omega_P_terms   + rho_P_terms
 
     return energy_density, Pressure
 


### PR DESCRIPTION
## Summary

In `get_energy_pressure_alpha` (used by `get_eos_alpha` to compute the α-fixed EOS — SNM at α=0.5, PNM at α=0), the ω quartic self-coupling and the ω-ρ cross term reuse the energy-density coefficients (ζ/8 and 3·Λ_w) for *both* ε and P. These should differ: ε picks up the extra factor of `g_ω ω ρ_B` through the ω-field equation of motion, whereas P = T^{ii} carries no matter-meson coupling to substitute.

Correct coefficients:

| Term | ε (energy density) | P (pressure) |
|---|---|---|
| ω quartic self-coupling | `+ ζ (g_ω ω)⁴ / 8` | `+ ζ (g_ω ω)⁴ / 24` |
| ω-ρ cross | `+ 3 Λ_w (g_ρ ρ_03 g_ω ω)²` | `+ 1 Λ_w (g_ρ ρ_03 g_ω ω)²` |

This PR splits the meson-field contributions into `omega_eps_terms / rho_eps_terms` (ε-side, unchanged) and `omega_P_terms / rho_P_terms` (P-side, corrected), and uses each where appropriate. Only the `Pressure` line changes; `energy_density` is numerically unchanged.

## Files touched

- `EOSgenerators/fastRMF_EoS.py` — `get_energy_pressure_alpha`
- `EOSgenerators/RMF_EOS.py` — `get_energy_pressure_alpha`
- `docs/source/fastRMF_EoS.py` — same function (doc mirror)

No changes to DDH generators (they have no ω⁴ or ω-ρ cross term — density-dependent couplings replace them), no changes to inference, TOV, or likelihood code. The β-equilibrium pressure path inside `compute_EOS` uses `P = multi − energy_density` (thermodynamic) and is untouched.

## Verification

**Formula-level check** at a fixed field point (`σ_sqrt=0.4, ω_sqrt=0.45, ρ_03=-0.03`) with NL3\*-like couplings:

```
analytical ΔP (pre − post)  =  (ζ/12)(g_ω ω)⁴ + 2·Λ_w (g_ρ ρ_03 g_ω ω)²   =  +25.203 MeV/fm³
measured   ΔP                                                              =  +25.203 MeV/fm³
|diff|                                                                     =  5.5 × 10⁻¹⁵ MeV/fm³  (machine precision)
```

Both `fastRMF_EoS` (numba) and `RMF_EOS` (non-numba) give identical output after the fix.

## Impact on existing inference — none

Every currently active likelihood either uses the β-equilibrium pressure (NICER, GW, pQCD) or reads only the energy-density return of `get_eos_alpha`:

| Constraint | Source | Quantity used | Affected? |
|---|---|---|:---:|
| NMP cost (`chiRMF_NMP`) | `get_eos_alpha` | E/A only (K₀ from d²(E/A)/dρ², plus S, L) | no |
| NICER M-R | `compute_EOS` (β-eq) | ε, P (β-eq P is thermodynamic) | no |
| GW170817 tidal | `compute_EOS` | ε, P | no |
| χEFT PNM | `get_eos_alpha(α=0)` | `contraint_quantity="e"` reads only `EOS_pnm[1]` | no |
| pQCD | `compute_EOS` | ε, P | no |

The buggy α-fixed P is computed but not consumed by any active likelihood. All existing inference posteriors remain valid.

### Caveat for future work

If χEFT is ever flipped to `contraint_quantity="p"` (to use the Hebeler et al. 2013 PNM-pressure constraint instead of the Huth et al. 2022 PNM-energy one), or any PNM-pressure constraint is added, the pre-fix P would bias the posterior. This PR fixes the bug before any such change lands.
